### PR TITLE
#11 Pull Info from github resources repo using Github recursive API plus minor refactor

### DIFF
--- a/resources-page/resources.css
+++ b/resources-page/resources.css
@@ -48,6 +48,7 @@ p {
     border-radius: 5px;
     padding: .5em;
     box-shadow: 1px 1px 1px 1px grey;
+    margin-bottom: 10px;
 }
 
 footer {

--- a/resources-page/resources.js
+++ b/resources-page/resources.js
@@ -1,3 +1,9 @@
+
+const GH_CONTENT_API_URL = 'https://api.github.com/repos/ufosc/resources/git/trees/eb7666402a1b2576457abcf174273d1fc93338ee?recursive=1';
+const GH_RAW_API_URL = 'https://cdn.rawgit.com/ufosc/resources/57f5e618/resources/';
+
+getContent();
+
 // display actual content once it's been fetched
 function display(content) {
   /* using showdown library that converts markdown into HTML */
@@ -12,9 +18,9 @@ function display(content) {
 }
 
 // HTTP REQUEST
-function getInfo(link, callback) {
+function get(url, callback) {
     var xhr = new XMLHttpRequest();
-    xhr.open("GET", link, true);
+    xhr.open('GET', url, true);
     xhr.onreadystatechange = function() {
         if (xhr.readyState === 4) {
           var data = xhr.responseText;
@@ -24,31 +30,17 @@ function getInfo(link, callback) {
     xhr.send(null);
 }
 
-/* slight callback hell 😅  */
-
-// call github API to get all files (names) from resources repo (may also contain directories)
-getInfo("https://api.github.com/repos/ufosc/resources/contents/resources", function(result) {
-  var jsonResponse = JSON.parse(result);
-  jsonResponse.forEach(function(list) {
-    console.log('file name: ', list.name);
-    // get actual content from each file in resources repo, only markdown files, and not the first README.md
-    if(list.name.includes('.md') && list.name != 'README.md') {
-        getInfo('https://cdn.rawgit.com/ufosc/resources/57f5e618/resources/' + list.name, function(result) {
-        console.log(result);
-        display(result);
-      });
-      // list.name is a directory, so fetch data from that directory
-    } else {
-        var dir = list.name;
-        getInfo('https://api.github.com/repos/ufosc/resources/contents/resources/' + dir, function(result) {
-          var jsonResponse = JSON.parse(result);
-          jsonResponse.forEach(function(list) {
-            console.log('file name: ', list.name);
-            getInfo('https://cdn.rawgit.com/ufosc/resources/57f5e618/resources/' + dir + '/' + list.name, function(result) {
+function getContent() {
+  get(GH_CONTENT_API_URL, function(result) {
+    var jsonResponse = JSON.parse(result);
+    jsonResponse.tree.forEach(function(file) {
+      var filePath = file.path;
+      if(filePath.includes('.md') && !filePath.includes('README.md')) {
+        get(GH_RAW_API_URL + filePath, function(result) {
+            console.log(result);
             display(result);
-          });
         });
-      });
-    }
+      }
+    });
   });
-});
+}


### PR DESCRIPTION
# Fixes

Issue #11 Still does what it's intended but code is much cleaner now.

I've been getting more comfortable with Javascript and figured I should try to refactor this code. 
On the last commit, I was using the [github's get contents api ](https://developer.github.com/v3/repos/contents/)to get the name of the files, but there were multiple callbacks and nested crap just to get ALL items.  Now I'm using github's [get tree recursively](https://developer.github.com/v3/git/trees/) which accomplishes the same but this time more efficiently.

***Note** (Especially to the person who's working on the UI): I'm using the [showdownjs library](https://github.com/showdownjs/showdown) to convert markdown to html. In order to use this, showdownjs file must be installed or the cdn must be present in the  resources.html file. For now, I decided to go with the CDN (linked in the resources.html` <head> </head>`). If no showdown library file or CDN is present, then the code will not work. 

